### PR TITLE
* Fix CI build failure

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/DbOperation.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/DbOperation.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             return Execute(cmd => cmd.ExecuteNonQueryAsync());
         }
 
-#if DNX451
+#if NET451
         public virtual int ExecuteReader(Action<IDataRecord, DbOperation> processRecord)
 #else
         public virtual int ExecuteReader(Action<DbDataReader, DbOperation> processRecord)
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             return ExecuteReader(processRecord, null);
         }
 
-#if DNX451
+#if NET451
         protected virtual int ExecuteReader(Action<IDataRecord, DbOperation> processRecord, Action<IDbCommand> commandAction)
 #else
         protected virtual int ExecuteReader(Action<DbDataReader, DbOperation> processRecord, Action<DbCommand> commandAction)
@@ -105,7 +105,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             });
         }
 
-#if DNX451
+#if NET451
         protected virtual IDbCommand CreateCommand(IDbConnection connection)
 #else
         protected virtual DbCommand CreateCommand(DbConnection connection)
@@ -125,7 +125,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             return command;
         }
 
-#if DNX451
+#if NET451
         private T Execute<T>(Func<IDbCommand, T> commandFunc)
 #else
         private T Execute<T>(Func<DbCommand, T> commandFunc)
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             }
         }
 
-#if DNX451
+#if NET451
         private void LoggerCommand(IDbCommand command)
 #else
         private void LoggerCommand(DbCommand command)
@@ -156,7 +156,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             }
         }
 
-#if DNX451
+#if NET451
         private async Task<T> Execute<T>(Func<IDbCommand, Task<T>> commandFunc)
 #else
         private async Task<T> Execute<T>(Func<DbCommand, Task<T>> commandFunc)

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/DbProviderFactoryAdapter.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/DbProviderFactoryAdapter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             _dbProviderFactory = dbProviderFactory;
         }
 
-#if DNX451
+#if NET451
         public IDbConnection CreateConnection()
 #else
         public DbConnection CreateConnection()

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/IDataRecordExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/IDataRecordExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if DNX451
+#if NET451
 using System;
 using System.Data;
 using System.Data.SqlClient;

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/IDbBehavior.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/IDbBehavior.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
         bool StartSqlDependencyListener();
         IList<Tuple<int, int>> UpdateLoopRetryDelays { get; }
 
-#if DNX451
+#if NET451
         void AddSqlDependency(IDbCommand command, Action<SqlNotificationEventArgs> callback);
 #endif
     }

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/IDbCommandExtensions.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/IDbCommandExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
     {
         private readonly static TimeSpan _dependencyTimeout = TimeSpan.FromSeconds(60);
 
-#if DNX451
+#if NET451
         public static void AddSqlDependency([NotNull]this IDbCommand command, Action<SqlNotificationEventArgs> callback)
         {
             var sqlCommand = command as SqlCommand;
@@ -29,7 +29,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
         }
 #endif
 
-#if DNX451
+#if NET451
         public static Task<int> ExecuteNonQueryAsync(this IDbCommand command)
 #else
         public static Task<int> ExecuteNonQueryAsync(this DbCommand command)
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
 
             if (sqlCommand != null)
             {
-#if DNX451
+#if NET451
                 return Task.Factory.FromAsync(
                     (cb, state) => sqlCommand.BeginExecuteNonQuery(cb, state),
                     iar => sqlCommand.EndExecuteNonQuery(iar),

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/IDbProviderFactory.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/IDbProviderFactory.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
 {
     public interface IDbProviderFactory
     {
-#if DNX451
+#if NET451
         IDbConnection CreateConnection();
 #else
         DbConnection CreateConnection();

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/ObservableDbOperation.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/ObservableDbOperation.cs
@@ -69,13 +69,13 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
         {
             Faulted += _ => { };
             Queried += () => { };
-#if DNX451
+#if NET451
             Changed += () => { };
 #endif
         }
 
         public event Action Queried;
-#if DNX451
+#if NET451
         public event Action Changed;
 #endif
         public event Action<Exception> Faulted;
@@ -85,7 +85,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
         /// </summary>
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Needs refactoring"),
          SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Errors are reported via the callback")]
-#if DNX451
+#if NET451
         public void ExecuteReaderWithUpdates(Action<IDataRecord, DbOperation> processRecord)
 #else
         public void ExecuteReaderWithUpdates(Action<DbDataReader, DbOperation> processRecord)
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
                         }
                         else
                         {
-#if DNX451
+#if NET451
                             // No records after all retries, set up a SQL notification
                             try
                             {
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
                 _disposing = true;
             }
 
-#if DNX451
+#if NET451
             if (_notificationState != NotificationState.Disabled)
             {
                 try
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             _stopHandle.Dispose();
         }
 
-#if DNX451
+#if NET451
         protected virtual void AddSqlDependency(IDbCommand command, Action<SqlNotificationEventArgs> callback)
         {
             command.AddSqlDependency(e => callback(e));
@@ -365,7 +365,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "I need to")]
         protected virtual bool StartSqlDependencyListener()
         {
-#if NETSTANDARDAPP1_5
+#if NETSTANDARD1_3
             return false;
 #else
             lock (_stopLocker)
@@ -420,7 +420,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
 
             if (_notificationState != NotificationState.Disabled)
             {
-#if DNX451
+#if NET451
                 try
                 {
                     Logger.LogDebug("{0}Stopping SQL notification listener", LoggerPrefix);
@@ -462,7 +462,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             get { return _updateLoopRetryDelays; }
         }
 
-#if DNX451
+#if NET451
         void IDbBehavior.AddSqlDependency(IDbCommand command, Action<SqlNotificationEventArgs> callback)
         {
             AddSqlDependency(command, callback);

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/SqlMessageBusException.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/SqlMessageBusException.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.AspNetCore.SignalR.SqlServer
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors", Justification="Should never have inner exceptions")]
-#if DNX451
+#if NET451
     [Serializable]
 #endif
     public class SqlMessageBusException : Exception

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/SqlPayload.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/SqlPayload.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             return message.ToBytes();
         }
 
-#if DNX451
+#if NET451
         public static ScaleoutMessage FromBytes(IDataRecord record)
 #else
         public static ScaleoutMessage FromBytes(DbDataReader record)

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/SqlReceiver.cs
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/SqlReceiver.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
 
             _dbOperation.Queried += () => Queried();
             _dbOperation.Faulted += ex => Faulted(ex);
-#if DNX451
+#if NET451
             _dbOperation.Changed += () =>
             {
                 _logger.LogInformation("{0}Starting receive loop again to process updates", _loggerPrefix);
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.SignalR.SqlServer
             _logger.LogInformation("{0}SqlReceiver.Receive returned", _loggerPrefix);
         }
 
-#if DNX451
+#if NET451
         private void ProcessRecord(IDataRecord record, DbOperation dbOperation)
 #else
         private void ProcessRecord(DbDataReader record, DbOperation dbOperation)

--- a/src/Microsoft.AspNetCore.SignalR.SqlServer/project.json
+++ b/src/Microsoft.AspNetCore.SignalR.SqlServer/project.json
@@ -11,18 +11,19 @@
   },
   "resources": "install.sql;send.sql",
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
         "System.Data": ""
       }
     },
-    "netstandardapp1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "System.Data.SqlClient": "4.0.0-*",
         "System.Runtime": "4.1.0-*"
       },
       "imports": [
-        "dnxcore50"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   }

--- a/test/Microsoft.AspNetCore.SignalR.SqlServer.Tests/project.json
+++ b/test/Microsoft.AspNetCore.SignalR.SqlServer.Tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.SignalR.SqlServer": "0.1.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
-    "xunit.runner.aspnet": "2.0.0-aspnet-*",
+    "xunit": "2.1.0",
     "Moq": "4.2.1312.1622"
   },
   "compilationOptions": {
@@ -11,6 +11,10 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "dnx451": {}
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Threading.Tasks": ""
+      }
+    }
   }
 }


### PR DESCRIPTION
Targeting DNX451 results in 

```
error: System.Runtime 4.0.20 provides a compile-time reference assembly for System.Runtime on DNX,Version=v4.5.1, but there is no run-time assembly compatible with win7-x64.
[10:35:54]error: Some packages are not compatible with DNX,Version=v4.5.1 (win7-x64).
[10:35:54]error: System.Runtime 4.0.20 provides a compile-time reference assembly for System.Runtime on DNX,Version=v4.5.1, but there is no run-time assembly compatible with win7-x86.
[10:35:54]error: Some packages are not compatible with DNX,Version=v4.5.1 (win7-x86).
```
